### PR TITLE
Defined an optional FAB delegate.

### DIFF
--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -89,6 +89,11 @@ public class KCFloatingActionButton: UIView {
     public var closed: Bool = true
     
     /**
+     Delegate that can be used to learn more about the behavior of the FAB widget.
+    */
+    @IBOutlet public var fabDelegate: KCFloatingActionButtonDelegate?
+    
+    /**
         Button shape layer.
     */
     private var circleLayer: CAShapeLayer = CAShapeLayer()
@@ -275,10 +280,16 @@ public class KCFloatingActionButton: UIView {
         Items open or close.
     */
     public func toggle() {
-        if closed == true {
-            open()
-        } else {
-            close()
+        if items.count > 0 {
+            if closed == true {
+                open()
+            } else {
+                close()
+            }
+        }
+        else if fabDelegate != nil
+        {
+            fabDelegate?.emptyKcfabSelected(self)
         }
     }
     

--- a/KCFloatingActionButton/KCFloatingActionButtonDelegate.swift
+++ b/KCFloatingActionButton/KCFloatingActionButtonDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  KCFloatingActionButtonDelegate.swift
+//  FAB Testing
+//
+//  Created by Nathan Russak on 2/23/16.
+//  Copyright © 2016 Nathan Russak. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Optional delegate that can be used to be notified whenever the user
+ taps on a FAB that does not contain any sub items.
+ */
+@objc public protocol KCFloatingActionButtonDelegate
+{
+    /**
+     Indicates that the user has tapped on a FAB widget that does not
+     contain any defined sub items.
+     - parameter fab: The FAB widget that was selected by the user.
+     */
+    func emptyKcfabSelected(fab: KCFloatingActionButton)
+}

--- a/Sample/KCFloatingActionButton-Sample.xcodeproj/project.pbxproj
+++ b/Sample/KCFloatingActionButton-Sample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		699DF1681C7CB0A8006663FE /* KCFloatingActionButtonDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699DF1671C7CB0A8006663FE /* KCFloatingActionButtonDelegate.swift */; };
 		B6640EA21BCEA8DA0099510D /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6640EA11BCEA8DA0099510D /* LaunchScreen.xib */; };
 		B675871E1BCCFEBC00C4BEAF /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B675871D1BCCFEBC00C4BEAF /* Icons.xcassets */; };
 		B67587241BCD4C4900C4BEAF /* KCFABManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B675871F1BCD4C4900C4BEAF /* KCFABManager.swift */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		699DF1671C7CB0A8006663FE /* KCFloatingActionButtonDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KCFloatingActionButtonDelegate.swift; path = ../../KCFloatingActionButton/KCFloatingActionButtonDelegate.swift; sourceTree = "<group>"; };
 		B6640EA11BCEA8DA0099510D /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		B675871D1BCCFEBC00C4BEAF /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Icons.xcassets; sourceTree = "<group>"; };
 		B675871F1BCD4C4900C4BEAF /* KCFABManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KCFABManager.swift; path = ../../KCFloatingActionButton/KCFABManager.swift; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 				B67587211BCD4C4900C4BEAF /* KCFABWindow.swift */,
 				B67587221BCD4C4900C4BEAF /* KCFloatingActionButton.swift */,
 				B67587231BCD4C4900C4BEAF /* KCFloatingActionButtonItem.swift */,
+				699DF1671C7CB0A8006663FE /* KCFloatingActionButtonDelegate.swift */,
 			);
 			name = KCFloatingActionButton;
 			sourceTree = "<group>";
@@ -169,6 +172,7 @@
 				B67587281BCD4C4900C4BEAF /* KCFloatingActionButtonItem.swift in Sources */,
 				B67587271BCD4C4900C4BEAF /* KCFloatingActionButton.swift in Sources */,
 				B6F66E1A1BC1017F00E47769 /* AppDelegate.swift in Sources */,
+				699DF1681C7CB0A8006663FE /* KCFloatingActionButtonDelegate.swift in Sources */,
 				B67587251BCD4C4900C4BEAF /* KCFABViewController.swift in Sources */,
 				B67587261BCD4C4900C4BEAF /* KCFABWindow.swift in Sources */,
 				B675872A1BCD4CBC00C4BEAF /* PushTestViewController.swift in Sources */,


### PR DESCRIPTION
Created a delegate protocol that can be expanded upon to include a bunch of additional events related to the behavior of the FAB. Right now it only contains a function that notifies the delegate when a user has tapped on a FAB that does not contain any defined sub items.

Not all FABs need to have nested child actions, so this is good for the user case where an app needs a FAB that represents just a single primary action.