### PR TITLE
Various changes/additions

### DIFF
--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -418,6 +418,7 @@ public class KCFloatingActionButton: UIView {
     private func setButtonImage() {
         buttonImageView.removeFromSuperview()
         buttonImageView = UIImageView(image: buttonImage)
+		buttonImageView.tintColor = plusColor
         buttonImageView.frame = CGRectMake(
             size/2 - buttonImageView.frame.size.width/2,
             size/2 - buttonImageView.frame.size.height/2,

--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -81,7 +81,12 @@ public class KCFloatingActionButton: UIView {
         Child item's default button color.
     */
     @IBInspectable public var itemButtonColor: UIColor = UIColor.whiteColor()
-    
+	
+	/**
+		Child item's image color
+	*/
+	@IBInspectable public var itemImageColor: UIColor = UIColor(white: 0.2, alpha: 1)
+	
     /**
         Child item's default shadow color.
     */
@@ -479,6 +484,7 @@ public class KCFloatingActionButton: UIView {
     
     private func itemDefaultSet(item: KCFloatingActionButtonItem) {
         item.buttonColor = itemButtonColor
+		item.iconImageView.tintColor = itemImageColor
         item.circleShadowColor = itemShadowColor
         item.titleShadowColor = itemShadowColor
         item.size = itemSize

--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -44,6 +44,11 @@ public class KCFloatingActionButton: UIView {
     }
 	
 	/**
+		Automatically closes child items when tapped
+	*/
+	@IBInspectable public var autoCloseOnTap: Bool = true
+	
+	/**
 		Degrees to rotate image
 	*/
 	@IBInspectable public var rotationDegrees: CGFloat = -45
@@ -316,6 +321,7 @@ public class KCFloatingActionButton: UIView {
     public func addItem(item item: KCFloatingActionButtonItem) {
         item.frame.origin = CGPointMake(size/2-item.size/2, size/2-item.size/2)
         item.alpha = 0
+		item.actionButton = self
         items.append(item)
         addSubview(item)
     }

--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -42,7 +42,11 @@ public class KCFloatingActionButton: UIView {
             self.setNeedsDisplay()
         }
     }
-    
+	
+	/**
+		Degrees to rotate image
+	*/
+	@IBInspectable public var rotationDegrees: CGFloat = -45
     /**
         Button color.
     */
@@ -218,7 +222,12 @@ public class KCFloatingActionButton: UIView {
                 usingSpringWithDamping: 0.55,
                 initialSpringVelocity: 0.3,
                 options: [.CurveEaseInOut], animations: { () -> Void in
-                    self.plusLayer.transform = CATransform3DMakeRotation(self.degreesToRadians(-45), 0.0, 0.0, 1.0)
+					if self.buttonImage == nil {
+						self.plusLayer.transform = CATransform3DMakeRotation(self.degreesToRadians(self.rotationDegrees), 0.0, 0.0, 1.0)
+					}
+					else {
+						self.buttonImageView.transform = CGAffineTransformMakeRotation(self.degreesToRadians(self.rotationDegrees))
+					}
                     self.overlayView.alpha = 1
                 }, completion: nil)
             
@@ -257,7 +266,12 @@ public class KCFloatingActionButton: UIView {
                 usingSpringWithDamping: 0.6,
                 initialSpringVelocity: 0.8,
                 options: [], animations: { () -> Void in
-                    self.plusLayer.transform = CATransform3DMakeRotation(self.degreesToRadians(0), 0.0, 0.0, 1.0)
+					if self.buttonImage == nil {
+						self.plusLayer.transform = CATransform3DMakeRotation(self.degreesToRadians(0), 0.0, 0.0, 1.0)
+					}
+					else {
+						self.buttonImageView.transform = CGAffineTransformMakeRotation(self.degreesToRadians(0))
+					}
                     self.overlayView.alpha = 0
                 }, completion: {(f) -> Void in
                     self.overlayView.removeFromSuperview()

--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -90,7 +90,7 @@ public class KCFloatingActionButton: UIView {
 	/**
 		Child item's image color
 	*/
-	@IBInspectable public var itemImageColor: UIColor = UIColor(white: 0.2, alpha: 1)
+	@IBInspectable public var itemImageColor: UIColor? = nil
 	
     /**
         Child item's default shadow color.
@@ -490,7 +490,10 @@ public class KCFloatingActionButton: UIView {
     
     private func itemDefaultSet(item: KCFloatingActionButtonItem) {
         item.buttonColor = itemButtonColor
-		item.iconImageView.tintColor = itemImageColor
+		
+		/// Use separate color (if specified) for item button image, or default to the plusColor
+		item.iconImageView.tintColor = itemImageColor ?? plusColor
+		
         item.circleShadowColor = itemShadowColor
         item.titleShadowColor = itemShadowColor
         item.size = itemSize

--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -225,7 +225,7 @@ public class KCFloatingActionButton: UIView {
             setOverlayView()
             self.superview?.insertSubview(overlayView, aboveSubview: self)
             self.superview?.bringSubviewToFront(self)
-            overlayView.addTarget(self, action: Selector("close"), forControlEvents: UIControlEvents.TouchUpInside)
+            overlayView.addTarget(self, action: #selector(close), forControlEvents: UIControlEvents.TouchUpInside)
 
             
             UIView.animateWithDuration(0.3, delay: 0,
@@ -271,7 +271,7 @@ public class KCFloatingActionButton: UIView {
     */
     public func close() {
         if(items.count > 0){
-            self.overlayView.removeTarget(self, action: Selector("close"), forControlEvents: UIControlEvents.TouchUpInside)
+            self.overlayView.removeTarget(self, action: #selector(close), forControlEvents: UIControlEvents.TouchUpInside)
             UIView.animateWithDuration(0.3, delay: 0,
                 usingSpringWithDamping: 0.6,
                 initialSpringVelocity: 0.8,
@@ -515,9 +515,9 @@ public class KCFloatingActionButton: UIView {
     }
     
     private func setObserver() {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "deviceOrientationDidChange:", name: UIDeviceOrientationDidChangeNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillShow:", name:UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillHide:", name:UIKeyboardWillHideNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(deviceOrientationDidChange(_:)), name: UIDeviceOrientationDidChangeNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(keyboardWillShow(_:)), name:UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(keyboardWillHide(_:)), name:UIKeyboardWillHideNotification, object: nil)
     }
     
     deinit {

--- a/KCFloatingActionButton/KCFloatingActionButtonItem.swift
+++ b/KCFloatingActionButton/KCFloatingActionButtonItem.swift
@@ -39,7 +39,12 @@ public class KCFloatingActionButtonItem: UIView {
         If you touch up inside button, it execute handler.
     */
     public var handler: ((KCFloatingActionButtonItem) -> Void)? = nil
-    
+	
+	/**
+		Reference to parent
+	*/
+	public weak var actionButton: KCFloatingActionButton?
+	
     /**
         Shape layer of button.
     */
@@ -194,6 +199,9 @@ public class KCFloatingActionButtonItem: UIView {
             let touch = touches.first
             if touch?.tapCount == 1 {
                 if touch?.locationInView(self) == nil { return }
+				if actionButton != nil && actionButton!.autoCloseOnTap {
+					actionButton!.close()
+				}
                 handler?(self)
             }
         }


### PR DESCRIPTION
- Use plusLayer color to tint custom images when used
- When using custom image instead of default plus image, rotate it as you would plusLayer
- Specify rotation degrees in IB
- Set child item image tint separately in IB. Default to plusColor when itemImageColor is left blank
- Auto-close items on item tap. Customizable in IB.
- Syntax updates for Swift 2.2