### PR TITLE
Removed closing the FAB from the hitTest method

### DIFF
--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -425,12 +425,6 @@ public class KCFloatingActionButton: UIView {
                     return item.hitTest(itemPoint, withEvent: event)
                 }
             }
-            
-            let buttonPoint = self.convertPoint(point, fromView: self)
-            if CGRectContainsPoint(self.bounds, buttonPoint) == false {
-                close()
-                return super.hitTest(point, withEvent: event)
-            }
         }
         
         return super.hitTest(point, withEvent: event)


### PR DESCRIPTION
This avoids side effects when calling the hitTest without actually tapping a button (i.e. in UI automation). It does not seem to change the component's behaviour under the assumption that, when you set autoCloseOnTap to false, the component does not have to handle closing in any case.

I propose this change because right now the component cannot be used by our test automation framework, but also because the way hitTest: is used in the component does not follow the expectations one might have when using this method.

I hope you can incorporate this change in a future version of your component. It's of great use in general!