### PR TITLE
Fix for the bug where tapping on the right side of the button item is…

### DIFF
--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -417,7 +417,7 @@ public class KCFloatingActionButton: UIView {
                 var itemPoint = item.convertPoint(point, fromView: self)
                 let size = CGRect(x: item.titleLabel.frame.origin.x + item.bounds.origin.x,
                                   y: item.bounds.origin.y,
-                                  width: item.titleLabel.bounds.size.width + item.bounds.size.width,
+                                  width: item.titleLabel.bounds.size.width + item.bounds.size.width + 30,
                                   height: item.bounds.size.height)
                 
                 if CGRectContainsPoint(size, itemPoint) == true {


### PR DESCRIPTION
Fix for the bug where tapping on the right side of the button item is not detected. The calculation doesn't seems to be taking into account of the padding/horizontal distance between the label and the icon. 