### PR TITLE
Fix .slideDown horizontal item misalignment

### DIFF
--- a/Sources/KCFloatingActionButton.swift
+++ b/Sources/KCFloatingActionButton.swift
@@ -864,7 +864,6 @@ extension KCFloatingActionButton {
             itemHeight += item.size + itemSpace
             UIView.animate(withDuration: 0.2, delay: 0, options: [], animations: { () -> Void in
                                         item.frame.origin.y = itemHeight
-                                        item.frame.origin.x = 4
                                         item.alpha = 1
                 }, completion: nil)
         }


### PR DESCRIPTION
Items are misaligned horizontally when using `openAnimationType = .slideDown`:

![screen shot 2016-12-06 at 13 55 07](https://cloud.githubusercontent.com/assets/52106/20926249/9cedf020-bbbb-11e6-8f33-3a018f8b7305.png)

Removing the line `item.frame.origin.x = 4` from `slideDownAnimationWithOpen()` fixes the issue for me:

![screen shot 2016-12-06 at 13 58 32](https://cloud.githubusercontent.com/assets/52106/20926334/16cc8cc6-bbbc-11e6-9940-04645f3e60e2.png)