### PR TITLE
fix overlay animation bug when opening/closing in quick succession

### DIFF
--- a/Sources/KCFloatingActionButton.swift
+++ b/Sources/KCFloatingActionButton.swift
@@ -172,6 +172,10 @@ open class KCFloatingActionButton: UIView {
 
     fileprivate var overlayView : UIControl = UIControl()
 
+    /**
+        Keep track of whether overlay open animation completes, to avoid animation conflicts.
+     */
+    fileprivate var overlayViewDidCompleteOpenAnimation: Bool = true
 
     /**
         If you created this object from storyboard or `initWithFrame`, this property set true.
@@ -258,6 +262,7 @@ open class KCFloatingActionButton: UIView {
             self.superview?.bringSubview(toFront: self)
             overlayView.addTarget(self, action: #selector(close), for: UIControlEvents.touchUpInside)
 
+            overlayViewDidCompleteOpenAnimation = false
             UIView.animate(withDuration: 0.3, delay: 0,
                 usingSpringWithDamping: 0.55,
                 initialSpringVelocity: 0.3,
@@ -265,7 +270,9 @@ open class KCFloatingActionButton: UIView {
                     self.plusLayer.transform = CATransform3DMakeRotation(self.degreesToRadians(self.rotationDegrees), 0.0, 0.0, 1.0)
                     self.buttonImageView.transform = CGAffineTransform(rotationAngle: self.degreesToRadians(self.rotationDegrees))
                     self.overlayView.alpha = 1
-                }, completion: nil)
+                }, completion: {(f) -> Void in
+                    self.overlayViewDidCompleteOpenAnimation = true
+            })
 
 
             switch openAnimationType {
@@ -302,7 +309,9 @@ open class KCFloatingActionButton: UIView {
                     self.buttonImageView.transform = CGAffineTransform(rotationAngle: self.degreesToRadians(0))
                     self.overlayView.alpha = 0
                 }, completion: {(f) -> Void in
-                    self.overlayView.removeFromSuperview()
+                    if self.overlayViewDidCompleteOpenAnimation {
+                        self.overlayView.removeFromSuperview()
+                    }
             })
 
             switch openAnimationType {


### PR DESCRIPTION
This fixes a bug that would remove the overlay after opening the menu if the menu was closed and opened in quick succession.

The issue is that if the menu is `open()`'ed before the `UIView.animate` closing animation completes, the `UIView.animate` `completion` block will be executed after the menu has been opened again. Thus the overlay will be removed from the open menu. 

Removing the overlay for an open menu produces two annoying effects:
1) The background is clearly visible, instead of being darkened by the overlay.
2) Tapping the background does not close the menu, as the tap gesture is tied to the overlay.

There might be a better way to do this, but it worked for me. :)